### PR TITLE
feat: criação de modal para edição de salas

### DIFF
--- a/app/(privated)/cadastrarSala/formularioVirtual.tsx
+++ b/app/(privated)/cadastrarSala/formularioVirtual.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, Dispatch, SetStateAction, useState } from "react"
 import { cadastrarSalaVirtual } from "./services/cadastrarSalaVirtual"
 import { FormControlInput } from "@/app/components/FormControlInput/FormControlInput"
 import { BtnCriarSala } from "@/app/components/buttons/IconBtns/BtnCriarSala&Usuario"
+import EditarSalaVirtual from "../editarSala/formEditVirtual"
 
 export default function CadastrarSalaVirtual() {
   const [nameValid, setNameValid] = useState(false)
@@ -39,7 +40,7 @@ export default function CadastrarSalaVirtual() {
       isValid = value.trim() !== '' && !value.startsWith(' ') && value.length <= 20
       setIsError(!isValid)
     } else if (id === 'link') {
-      isValid = value.trim() !== '' && !value.startsWith(' ') && value.length <= 20
+      isValid = value.trim() !== '' && !value.startsWith(' ') && /^(ftp|http|https):\/\/[^ "]+$/.test(value)
       setIsError(!isValid)
     }
     setRoom(prevState => ({
@@ -55,7 +56,7 @@ export default function CadastrarSalaVirtual() {
     } else if (id === 'password') {
       setPasswordValid(isValid)
     } else if (id === 'link') {
-      setPasswordValid(isValid)
+      setLinkValid(isValid)
     }
   }
 
@@ -130,7 +131,7 @@ export default function CadastrarSalaVirtual() {
               </Select>
             </Flex>
             <Text color={'black'} textAlign={'center'}>By proceeding you agree with our <span>Terms of Service</span> & <span>Privacy Policy</span></Text>
-            <BtnCriarSala type={'submit'} isDisabled={!isFormValid} />
+            <BtnCriarSala type={'submit'} isDisabled={!isFormValid}/>
           </Center>
         </Center>
       </form>

--- a/app/(privated)/editarSala/formEditPresencial.tsx
+++ b/app/(privated)/editarSala/formEditPresencial.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { Center, Flex, Select, useToast, Text, Heading, useDisclosure, Modal, ModalContent, ModalFooter, ModalBody, FormControl, FormLabel, ModalCloseButton, ModalHeader, ModalOverlay, Button, Input } from "@chakra-ui/react"
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react"
+import { editarSalaPresencial } from "./services/editarSalaPresencial"
+import { FormControlInput } from "@/app/components/FormControlInput/FormControlInput"
+import { BtnEditar, BtnSalvar } from "@/app/components/buttons/IconBtns/BtnEditar&Salvar"
+import React from "react"
+import { BtnCancelar } from "@/app/components/buttons/IconBtns/BtnDesmarcar&Cancelar"
+
+export default function EditarSalaPresencial(){
+    const [nameValid, setNameValid] = useState(false)
+    const [capacityValid, setCapacityValid] = useState(false)
+    const [localityValid, setLocalityValid] = useState(false)
+    const { isOpen, onOpen, onClose } = useDisclosure()
+    const initialRef = React.useRef(null)
+
+    //Objeto para editar sala
+    const [room, setRoom] = useState({
+        name: '',
+        capacity: '',
+        permissionLevel: 0,
+        locality: ''
+    })
+
+    const toast = useToast()
+
+
+    const isPermissionLevelValid = [1, 2, 3].includes(room.permissionLevel); //Ivan: Eu criei essa variavel para validar somente se 1, 2 ou 3 fossem selecionados.
+    const isFormValid = capacityValid && nameValid && localityValid && isPermissionLevelValid
+  
+    const handleInputChange = (e: ChangeEvent<HTMLInputElement>, setIsError: Dispatch<SetStateAction<boolean>>) => {
+      const { id, value } = e.target
+      let isValid = true
+      // função para lidar com as alterações do formulário e quando o usuário fizer algo errado mostrar erro no campo
+      if (id === 'name') {
+        isValid = value.trim() !== '' && value.length <= 80 && !value.startsWith(' ')
+        setIsError(!isValid)
+      } else if (id === 'capacity') {
+        isValid = value.trim() !== '' && !value.startsWith(' ')
+        setIsError(!isValid)
+      } else if (id === 'locality') {
+        isValid = value.trim() !== '' && !value.startsWith(' ')
+        setIsError(!isValid)
+      }
+
+  
+      setRoom(prevState => ({
+        ...prevState,
+        [id]: value
+      }))
+  
+  
+      // Atualiza o estado de validade do campo
+      if (id === 'name') {
+        setNameValid(isValid)
+      } else if (id === 'capacity') {
+        setCapacityValid(isValid)
+      } else if (id === 'locality') {
+        setLocalityValid(isValid)
+      }
+    }
+
+    const submit = (e: any) => {
+        // função que envia os dados do formulário para o backend
+        e.preventDefault()
+    
+        const body = {
+          "physical_room_name": room.name,
+          "physical_room_vacancies": Number.parseInt(room.capacity),
+          "physical_room_permission_level": room.permissionLevel,
+          "physical_room_address": room.locality
+        }
+
+    const request = editarSalaPresencial(body)
+
+    toast.promise(request, {
+        success: {
+          title: 'Edição de sala concluída',
+          description: 'com sucesso.',
+          position: 'top',
+          isClosable: true,
+        },
+  
+        error: {
+          title: 'Erro',
+          description: 'Erro ao editar sala',
+          position: 'top',
+          isClosable: true,
+        },
+  
+        loading: {
+          title: 'Editando informações da sala',
+          description: 'Por favor, espere um momento',
+          position: 'top',
+          isClosable: true,
+        },
+      })
+  
+      setRoom({
+        name: '',
+        capacity: '',
+        permissionLevel: 0,
+        locality:''
+      })
+      setCapacityValid(false)
+      setNameValid(false)
+      setLocalityValid(false)
+
+      
+    }
+    return (
+        <main>
+          <form method="POST" onSubmit={submit}>
+      <BtnEditar onClick={onOpen}/>
+
+      <Modal
+        initialFocusRef={initialRef}
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Edição de sala</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+          <FormControlInput id='name' input={room.name} handleInputChange={handleInputChange} campo="Nome" type="" />
+          <FormControlInput id='capacity' input={room.capacity} handleInputChange={handleInputChange} campo="Capacidade" type="number" />
+          <FormControlInput id='locality' input={room.locality} handleInputChange={handleInputChange} campo="Endereço / Local" type="" />
+          <Flex w='100%' gap="1rem" marginTop={4}><Heading fontWeight={'normal'} whiteSpace={'nowrap'}>Nível de Permissão</Heading>
+              <Select placeholder='Escolha o Nível de Permissão' value={room.permissionLevel} onChange={(e: ChangeEvent<HTMLSelectElement>) => setRoom({
+                ...room, permissionLevel: Number.parseInt(e.target.value)
+              })}>
+                <option value={1}>1</option>
+                <option value={2}>2</option>
+                <option value={3}>3</option>
+              </Select>
+            </Flex>
+          </ModalBody>
+          <ModalFooter gap={3}>
+            <BtnSalvar type={'submit'} isDisabled={!isFormValid}/>
+            <BtnCancelar onClick={onClose}/>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+          </form>
+        </main>
+      )
+
+}

--- a/app/(privated)/editarSala/formEditPresencial.tsx
+++ b/app/(privated)/editarSala/formEditPresencial.tsx
@@ -111,7 +111,7 @@ export default function EditarSalaPresencial(){
     }
     return (
         <main>
-          <form method="POST" onSubmit={submit}>
+          <form method="PUT" onSubmit={submit}>
       <BtnEditar onClick={onOpen}/>
 
       <Modal

--- a/app/(privated)/editarSala/formEditVirtual.tsx
+++ b/app/(privated)/editarSala/formEditVirtual.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { Center, Flex, Select, useToast, Text, Heading, useDisclosure, Modal, ModalContent, ModalFooter, ModalBody, FormControl, FormLabel, ModalCloseButton, ModalHeader, ModalOverlay, Button, Input } from "@chakra-ui/react"
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react"
+import { FormControlInput } from "@/app/components/FormControlInput/FormControlInput"
+import { BtnEditar, BtnSalvar } from "@/app/components/buttons/IconBtns/BtnEditar&Salvar"
+import React from "react"
+import { BtnCancelar } from "@/app/components/buttons/IconBtns/BtnDesmarcar&Cancelar"
+import { editarSalaVirtual } from "./services/editarSalaVirtual"
+
+export default function EditarSalaVirtual(){
+    const [nameValid, setNameValid] = useState(false)
+    const [linkValid, setLinkValid] = useState(false)
+    const { isOpen, onOpen, onClose } = useDisclosure()
+    const initialRef = React.useRef(null)
+
+      // Objeto para editar sala
+  const [room, setRoom] = useState({
+    name: '',
+    link: '',
+    permissionLevel: 0
+  })
+
+  const toast = useToast()
+  const isPermissionLevelValid = [1, 2, 3].includes(room.permissionLevel);
+  const isFormValid = nameValid  && linkValid && isPermissionLevelValid;
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>, setIsError: Dispatch<SetStateAction<boolean>>) => {
+    const { id, value } = e.target
+    let isValid = true
+    // função para lidar com as alterações do formulário e quando o usuário fizer algo errado mostrar erro no campo
+    if (id === 'name') {
+      isValid = value.trim() !== '' && value.length <= 80 && !value.startsWith(' ')
+      setIsError(!isValid)
+    } else if (id === 'link') {
+      isValid = value.trim() !== '' && !value.startsWith(' ') && /^(ftp|http|https):\/\/[^ "]+$/.test(value)
+      setIsError(!isValid)
+    }
+    setRoom(prevState => ({
+      ...prevState,
+      [id]: value
+    }))
+
+    // Atualiza o estado de validade do campo
+    if (id === 'name') {
+      setNameValid(isValid)
+    } else if (id === 'link') {
+      setLinkValid(isValid)
+    } 
+  }
+
+  const submit = (e: any) => {
+    // função que envia os dados do formulário para o backend
+    e.preventDefault()
+    
+        const body = {
+            "virtual_room_name": room.name,
+            "virtual_room_link": room.link,
+            "virtual_room_permission_level": room.permissionLevel
+          }
+
+    const request = editarSalaVirtual(body)
+
+    toast.promise(request, {
+        success: {
+          title: 'Edição de sala concluída',
+          description: 'com sucesso.',
+          position: 'top',
+          isClosable: true,
+        },
+  
+        error: {
+          title: 'Erro',
+          description: 'Erro ao editar sala',
+          position: 'top',
+          isClosable: true,
+        },
+  
+        loading: {
+          title: 'Editando informações da sala',
+          description: 'Por favor, espere um momento',
+          position: 'top',
+          isClosable: true,
+        },
+      })
+  
+      setRoom({
+        name: '',
+        link: '',
+        permissionLevel: 0
+      })
+      setNameValid(false)
+      setLinkValid(false)
+
+      
+    }
+    return (
+        <main>
+          <form method="POST" onSubmit={submit}>
+      <BtnEditar onClick={onOpen}/>
+
+      <Modal
+        initialFocusRef={initialRef}
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Edição de sala</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+          <FormControlInput id='name' input={room.name} handleInputChange={handleInputChange} campo="Nome" type="" />
+          <FormControlInput id='link' input={room.link} handleInputChange={handleInputChange} campo="Link" type="" />
+            <Flex w='100%' gap="1rem" marginTop={4}><Heading fontWeight={'normal'} whiteSpace={'nowrap'}>Nível de Permissão</Heading>
+              <Select placeholder='Escolha o Nível de Permissão' value={room.permissionLevel} onChange={(e: ChangeEvent<HTMLSelectElement>) => setRoom({
+                ...room, permissionLevel: Number.parseInt(e.target.value)
+              })}>
+                <option value={1}>1</option>
+                <option value={2}>2</option>
+                <option value={3}>3</option>
+              </Select>
+            </Flex>
+          </ModalBody>
+          <ModalFooter gap={3}>
+            <BtnSalvar type={'submit'} isDisabled={!isFormValid}/>
+            <BtnCancelar onClick={onClose}/>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+          </form>
+        </main>
+      )
+
+}

--- a/app/(privated)/editarSala/formEditVirtual.tsx
+++ b/app/(privated)/editarSala/formEditVirtual.tsx
@@ -59,6 +59,8 @@ export default function EditarSalaVirtual(){
             "virtual_room_permission_level": room.permissionLevel
           }
 
+          
+
     const request = editarSalaVirtual(body)
 
     toast.promise(request, {
@@ -96,7 +98,7 @@ export default function EditarSalaVirtual(){
     }
     return (
         <main>
-          <form method="POST" onSubmit={submit}>
+          <form method="PUT" onSubmit={submit}>
       <BtnEditar onClick={onOpen}/>
 
       <Modal
@@ -130,5 +132,4 @@ export default function EditarSalaVirtual(){
           </form>
         </main>
       )
-
 }

--- a/app/(privated)/editarSala/services/editarSalaPresencial.tsx
+++ b/app/(privated)/editarSala/services/editarSalaPresencial.tsx
@@ -10,7 +10,7 @@ export async function editarSalaPresencial(body: {}) {
   const session = await getServerSession(authOptions)
 
   const request = await fetch(BACKEND_URL + '/physicalrooms', {
-    method: 'POST',
+    method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ` + session?.backendTokens.access_token

--- a/app/(privated)/editarSala/services/editarSalaPresencial.tsx
+++ b/app/(privated)/editarSala/services/editarSalaPresencial.tsx
@@ -1,0 +1,25 @@
+'use server'
+import { BACKEND_URL } from "@/app/constants";
+import { authOptions } from "@/app/utils/authOptions";
+import { getServerSession } from "next-auth"
+/*
+ * envia o body para edição da sala no backend
+ *
+ * */
+export async function editarSalaPresencial(body: {}) {
+  const session = await getServerSession(authOptions)
+
+  const request = await fetch(BACKEND_URL + '/physicalrooms', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ` + session?.backendTokens.access_token
+    },
+    body: JSON.stringify(body)
+  })
+
+
+  const response = request
+  if (!response.ok) throw new Error(await response.text())
+  return response.json()
+}

--- a/app/(privated)/editarSala/services/editarSalaVirtual.tsx
+++ b/app/(privated)/editarSala/services/editarSalaVirtual.tsx
@@ -1,0 +1,25 @@
+'use server'
+import { BACKEND_URL } from "@/app/constants";
+import { authOptions } from "@/app/utils/authOptions";
+import { getServerSession } from "next-auth"
+/*
+ * envia o body para edição da sala no backend
+ *
+ * */
+export async function editarSalaVirtual(body: {}) {
+  const session = await getServerSession(authOptions)
+
+  const request = await fetch(BACKEND_URL + '/virtualrooms', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ` + session?.backendTokens.access_token
+    },
+    body: JSON.stringify(body)
+  })
+
+
+  const response = request
+  if (!response.ok) throw new Error(await response.text())
+  return response.json()
+}

--- a/app/(privated)/editarSala/services/editarSalaVirtual.tsx
+++ b/app/(privated)/editarSala/services/editarSalaVirtual.tsx
@@ -9,8 +9,9 @@ import { getServerSession } from "next-auth"
 export async function editarSalaVirtual(body: {}) {
   const session = await getServerSession(authOptions)
 
+
   const request = await fetch(BACKEND_URL + '/virtualrooms', {
-    method: 'POST',
+    method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ` + session?.backendTokens.access_token

--- a/app/(privated)/visualizarSala/components/SalasVisual.tsx
+++ b/app/(privated)/visualizarSala/components/SalasVisual.tsx
@@ -8,6 +8,7 @@ import { PhysicalRooms } from "@/app/type/rooms";
 import { excluirSala } from "../service/excluirSala";
 import { BtnRemover } from "@/app/components/buttons/IconBtns/BtnRemover&Entrar";
 import { BtnEditar } from "@/app/components/buttons/IconBtns/BtnEditar&Salvar";
+import EditarSalaPresencial from "../../editarSala/formEditPresencial";
 
 export default function SalasVisual() {
     const [salasPresenciais, setSalasPresenciais] = useState<PhysicalRooms[]>(new Array<PhysicalRooms>());
@@ -52,7 +53,7 @@ export default function SalasVisual() {
                             <Cards.HeaderPhysical room_name={sala.physical_room_name} />
                             <Cards.BodySalaAdm nivelDePermissao={sala.physical_room_permission_level} capacidade={sala.physical_room_vacancies}>
                                 <BtnRemover onClick={() => handleClick(sala)} zIndex={2}>Excluir</BtnRemover>
-                                <BtnEditar zIndex={2}>Editar</BtnEditar>
+                                <EditarSalaPresencial/>
                             </Cards.BodySalaAdm>
                         </Cards.Root>
                         }</>

--- a/app/(privated)/visualizarSala/components/SalasVisualVirtual.tsx
+++ b/app/(privated)/visualizarSala/components/SalasVisualVirtual.tsx
@@ -7,7 +7,7 @@ import { Cards } from "@/app/components/cards";
 import { VirtualRoom } from "@/app/type/rooms";
 import { excluirSalaVirtual } from "../service/excluirSala";
 import { BtnRemover } from "@/app/components/buttons/IconBtns/BtnRemover&Entrar";
-import { BtnEditar } from "@/app/components/buttons/IconBtns/BtnEditar&Salvar";
+import EditarSalaVirtual from "../../editarSala/formEditVirtual";
 
 export default function SalasVisualVirtual() {
     const [SalasVirtuais, setSalasVirtuais] = useState<VirtualRoom[]>(new Array<VirtualRoom>());
@@ -52,7 +52,7 @@ export default function SalasVisualVirtual() {
                             <Cards.HeaderVirtual room_name={sala.virtual_room_name} />
                             <Cards.BodySalaAdm nivelDePermissao={sala.virtual_room_permission_level} capacidade={0}>
                                 <BtnRemover onClick={() => (handleClick(sala))} zIndex={2}>Excluir</BtnRemover>
-                                <BtnEditar zIndex={2}>Editar</BtnEditar>
+                                <EditarSalaVirtual/>
                             </Cards.BodySalaAdm>
                         </Cards.Root>
                         }</>


### PR DESCRIPTION
Botões que abrem modal criados para possibilitar edição de salas (Virtuais e Presenciais), aplicada correção na lógica do link das salas virtuais.
Pontos importantes: 
- testei botão modal em outra parte do front, pois não consegui criar salas para testar corretamente, mas funcionou;
- Verifiquem se está registrando as alterações no backend, pois alterei pouca coisa do que fiz no form de cadastro.

Qualquer apontamento me notifiquem por favor.